### PR TITLE
Remove code to check 'search' key in frontmatter

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -70,12 +70,6 @@ module.exports = (options, ctx) => {
       }
 
       for (const page of ctx.pages) {
-        const frontmatter = page._computed.$frontmatter;
-
-        if (frontmatter.search === false) {
-          continue;
-        }
-
         if (searchPathPatterns !== null) {
           if (!searchPathPatterns.some(pattern => pattern.test(page.regularPath))) {
             continue;


### PR DESCRIPTION
## Related

- #9 

## Overview

Frontmatter

```
---
search: false
---
```

is not for excluding that page from search, but for hiding search box on that page.

`Navbar.vue` of `theme-default` plugin:

https://github.com/vuejs/vuepress/blob/v1.9.9/packages/%40vuepress/theme-default/components/Navbar.vue#L33