### PR TITLE
env variable for disable tokenizer

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -58,6 +58,13 @@ module.exports = (options, ctx) => {
     ],
 
     async ready() {
+      // For local dev server.
+      // Skip to run tokenizer if there are too many pages
+      // and so it takes long time to launch.
+      if (process.env.VUEPRESS_FLEXSEARCH === 'disabled') {
+        return;
+      }
+
       /** @type {Map<string, Map<string, Object>>} */
       const localeBasedPageData = new Map([
         ['/', new Map()],


### PR DESCRIPTION
Terminate `ready()` if `process.env.VUEPRESS_FLEXSEARCH` is defined as `'disabled'`

## npm run script example

```json
{
  "scripts": {
    "dev": "vuepress dev docs",
    "dev:light": "VUEPRESS_FLEXSEARCH=disabled vuepress dev docs",
    "build": "vuepress build docs"
  }
}
```