### PR TITLE
Display the first part of the content for excerpt when no query words found in it

### DIFF
--- a/src/components/excerpt.js
+++ b/src/components/excerpt.js
@@ -43,7 +43,7 @@ const create = (content, query, option) => {
     }
   }
 
-  return '';
+  return content.slice(0, aroundLength) + (content.length > aroundLength ? tailText : '');
 };
 
 /**

--- a/test/components/excerpt.js
+++ b/test/components/excerpt.js
@@ -9,42 +9,86 @@ describe('components', () => {
     const dataSet = [
       [
         'css',
+        {},
         'html, css, javascript',
         'html, <strong>css</strong>, javascript',
+      ],
+      [
+        'css',
+        { aroundLength: 5 },
+        'html, css, javascript',
+        '... tml, <strong>css</strong>, jav ...',
       ],
 
       [
         'hello hello hello',
+        {},
         'hello, world.',
         '<strong>hello</strong>, world.',
       ],
 
       [
         'java javascript',
+        {},
         'Java and JavaScript',
         '<strong>Java</strong> and <strong>JavaScript</strong>',
       ],
       [
         'Java JavaScript',
+        {},
         'Java and JavaScript',
         '<strong>Java</strong> and <strong>JavaScript</strong>',
       ],
       [
         'Java JavaScript',
+        {},
         'java and javascript',
         '<strong>java</strong> and <strong>javascript</strong>',
       ],
 
       [
         'bug',
+        {},
         'It is <b>NOT</b> a bug',
         'It is &lt;b&gt;NOT&lt;/b&gt; a <strong>bug</strong>',
       ],
+
+      [
+        '9',
+        {},
+        'weight is 999kg',
+        'weight is <strong>9</strong><strong>9</strong><strong>9</strong>kg',
+      ],
+      [
+        '99',
+        {},
+        'weight is 999kg',
+        'weight is <strong>99</strong>9kg',
+      ],
+      [
+        '999',
+        {},
+        'weight is 999kg',
+        'weight is <strong>999</strong>kg',
+      ],
+      [
+        '9999',
+        {},
+        'weight is 999kg',
+        'weight is 999kg',
+      ],
+      [
+        '9999',
+        { aroundLength: 5 },
+        'weight is 999kg',
+        'weigh ...',
+      ],
+
     ];
 
-    dataSet.forEach(([query, content, highlighted]) => {
-      it(`query: ${query}, content: ${content}`, () => {
-        const result = excerpt.create(content, query);
+    dataSet.forEach(([query, option, content, highlighted]) => {
+      it(`query: ${query}, option: ${JSON.stringify(option)} content: ${content}`, () => {
+        const result = excerpt.create(content, query, option);
 
         assert.deepStrictEqual(result, highlighted);
       });


### PR DESCRIPTION
## Example

Suppose markdown file contains:

```
... www.example.com ...
```

If search query is:

```
wwww
````

it will be preprocessed by n-gram, and actually searched with:

```
www www ww w
```

Above markdown file will be hit by search, but plugin cannot highlight any part of the file.


## How to fix

Display first `aroundLength` length texts of the content.